### PR TITLE
Keep checking for Cassandra until it's ready

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,7 @@ before_install:
   - sudo service cassandra start
 
 before_script:
-  - sleep 8
+  - while [ `nc localhost 9042 < /dev/null; echo $?` != 0 ] ; do
+      echo 'waiting for cassandra...' ;
+      sleep 1 ;
+    done


### PR DESCRIPTION
Instead of waiting for exactly 8 seconds for Cassandra to start, this checks once per second for Cassandra on _localhost:9042_.  As soon as the port is found to open, the build continues.
